### PR TITLE
feat: min coins change

### DIFF
--- a/dynamic_programming/min_coins_to_change.go
+++ b/dynamic_programming/min_coins_to_change.go
@@ -1,0 +1,23 @@
+package dynamic_programming
+
+func MinCoinsToChange(amount int, coins []int) int {
+	totalOfCoins := 0
+	amountLeft := amount //initially, the amount left is the amount itself
+
+	for i := len(coins) - 1; i >= 0; i-- { //iterate from the biggest coin to the smallest
+		if coins[i] > amount { //if the coin is bigger than the amount, skip it
+			continue
+		}
+		if coins[i] == amount { //jackpot!
+			return 1
+		}
+		var nCoins = amountLeft / coins[i] //find the current number of coins
+		amountLeft = amountLeft % coins[i] //find the amount left
+		totalOfCoins += nCoins             //add the number of coins to the total
+
+		if amountLeft == 0 { //if there is no amount left, we found a solution
+			return totalOfCoins
+		}
+	}
+	return -1 //if we got here, it means that we couldn't find a solution
+}

--- a/dynamic_programming/min_coins_to_change_test.go
+++ b/dynamic_programming/min_coins_to_change_test.go
@@ -1,0 +1,114 @@
+package dynamic_programming
+
+import (
+	"testing"
+)
+
+func TestMinCoinsToChange2(t *testing.T) {
+	tests := []struct {
+		name     string
+		amount   int
+		coins    []int
+		expected int
+	}{
+		{
+			name:     "Amount one with one coin",
+			amount:   1,
+			coins:    []int{1},
+			expected: 1,
+		},
+		{
+			name:     "Amount five with one, five, and ten coins",
+			amount:   5,
+			coins:    []int{1, 5, 10},
+			expected: 1,
+		},
+		{
+			name:     "Amount ten with one, five, and ten coins",
+			amount:   10,
+			coins:    []int{1, 5, 10},
+			expected: 1,
+		},
+		{
+			name:     "Amount twenty-five with all coins",
+			amount:   25,
+			coins:    []int{1, 5, 10, 25},
+			expected: 1,
+		},
+		{
+			name:     "Amount fifty with all coins",
+			amount:   50,
+			coins:    []int{1, 5, 10, 25},
+			expected: 2,
+		},
+		{
+			name:     "Amount fifteen with one, five, and ten coins",
+			amount:   15,
+			coins:    []int{1, 5, 10},
+			expected: 2,
+		},
+		{
+			name:     "Zero amount with empty coins slice",
+			amount:   0,
+			coins:    []int{},
+			expected: -1,
+		},
+		{
+			name:     "One amount with empty coins slice",
+			amount:   1,
+			coins:    []int{},
+			expected: -1,
+		},
+		{
+			name:     "Zero amount with non-empty coins slice",
+			amount:   0,
+			coins:    []int{1, 5, 10, 25},
+			expected: -1,
+		},
+		{
+			name:     "One amount with non-empty coins slice",
+			amount:   1,
+			coins:    []int{5, 10, 25},
+			expected: -1,
+		},
+		{
+			name:     "Amount five with one coin",
+			amount:   5,
+			coins:    []int{1},
+			expected: 5,
+		},
+		{
+			name:     "Amount hundred with one coin",
+			amount:   100,
+			coins:    []int{1},
+			expected: 100,
+		},
+		{
+			name:     "Amount five with one five coin",
+			amount:   5,
+			coins:    []int{5},
+			expected: 1,
+		},
+		{
+			name:     "Amount hundred with one twenty-five coin",
+			amount:   100,
+			coins:    []int{25},
+			expected: 4,
+		},
+		{
+			name:     "Amount hundred with all coins",
+			amount:   100,
+			coins:    []int{1, 5, 10, 25},
+			expected: 4,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MinCoinsToChange(tt.amount, tt.coins)
+			if got != tt.expected {
+				t.Errorf("MinCoinsToChange() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### The time complexity of the MinCoinsToChange function 
is `O(n)`, where n is the length of the input slice coins. This is because the function iterates through the input coins slice once, performing a constant amount of work for each element in the slice. Therefore, the time complexity of the function is proportional to the length of the input coins slice, resulting in a time complexity of `O(n)`.

### The space complexity of the MinCoinsToChange function is 
`O(1`), which means that the amount of memory used by the function does not depend on the size of the input. The function only uses a constant amount of memory to store the totalOfCoins and amountLeft variables, regardless of the size of the input. Therefore, the space complexity of the function is `O(1)`.